### PR TITLE
fix: replace JSON import assertion with fs.readFileSync

### DIFF
--- a/localhost_servers/start_servers.js
+++ b/localhost_servers/start_servers.js
@@ -1,7 +1,7 @@
 import { spawn, execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
-import servers from './servers.json' assert { type: 'json' };
+const servers = JSON.parse(fs.readFileSync("./servers.json", "utf8"));
 
 const startNeurite = process.argv.includes('neurite');
 


### PR DESCRIPTION
Replace unsupported JSON module import assertion with Node's native file system read method for better compatibility across Node.js versions.

This fix was to address an issue I experienced on MacBook Air M2 Version 15.1.
Here is the original error:
```
start_servers.js:4
import servers from './servers.json' assert { type: 'json' };
                                     ^^^^^^

SyntaxError: Unexpected identifier 'assert'
    at compileSourceTextModule (node:internal/modules/esm/utils:338:16)
    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:103:18)
    at #translate (node:internal/modules/esm/loader:437:12)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:484:27)
    at async ModuleJob._link (node:internal/modules/esm/module_job:115:19)

Node.js v23.3.0
```

Note: The original code work as expected on a Windows 10 environment. 

