### PR TITLE
Include key for custom endpoints

### DIFF
--- a/js/ai/ai-utility/handleapikeys.js
+++ b/js/ai/ai-utility/handleapikeys.js
@@ -346,6 +346,7 @@ function getAPIParams(messages, stream, customTemperature, inferenceOverride) {
 
     if (providerId === 'ollama' || providerId === 'custom') {
         body.requestId = Date.now().toString();
+		headers.append("Authorization", `Bearer ${API_KEY}`);
     }
 
     if (apiEndpoint) {


### PR DESCRIPTION
It doesn't send api key header for custom endpoints and give this error;
`ERR: In calling Chat API: Unexpected token 'A', "Authentica"... is not valid JSON`

This fix adds Authorization headers to custom endpoints. It also adds the header to ollama too but didn't encounter any issues.