### PR TITLE
Fix: Ensure PDF content is displayed after upload

### DIFF
--- a/js/interface/handledrop.js
+++ b/js/interface/handledrop.js
@@ -247,6 +247,7 @@ class DropHandler {
         const node = new LinkNode(url, name);
         node.fileName = name;
         this.afterNodeCreation(node);
+        node.typeNode.toggleViewer?.(); // Ensure the PDF viewer is initialized and content loaded
     }
 
     createLinkNode(link) {


### PR DESCRIPTION
Previously, when a PDF was uploaded, a LinkNode was created with the correct blob URL, but the internal iframe/webview's src attribute was never set, resulting in a blank viewer.

This change adds a call to `node.typeNode.toggleViewer?.()` in the `createPDFNode` function within `js/interface/handledrop.js`. This ensures that the LinkNode's viewer is initialized and the PDF content is loaded and displayed, mirroring the behavior of regular link creations.